### PR TITLE
fixed crash when response doesn't contain boundary in MTOM context

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,8 +74,9 @@ function extractContentId(id) {
   return id.substring(1, id.length-1)
 }
 
-function parseBoundary(contentType) {		
-  return contentType.match('boundary=\"(.*?)\"')[1]
+function parseBoundary(contentType) {
+  var matches = contentType.match('boundary=\"(.*?)\"');
+  return matches && matches.length > 0 && matches[1];
 }
 
 function dateDiffInMin(d1, d2) {


### PR DESCRIPTION
Hi,

There was a problem when the response to an MTOM request doesn't contain a boundary; in that case `match` returns null and a `TypeError` is thrown. This issue has been raised before but fixes have never been integrated in your master branch.

Cheers,
Jan