### PR TITLE
fixed crash when attached file is empty

### DIFF
--- a/lib/handlers/client/mtom/mtom.js
+++ b/lib/handlers/client/mtom/mtom.js
@@ -22,7 +22,7 @@ MtomClientHandler.prototype.send = function(ctx, callback) {
   for (var i in ctx.base64Elements) {		
     var file = ctx.base64Elements[i]
 		  , elem = select(doc, file.xpath)[0]
-      , binary = new Buffer(elem.firstChild.data, 'base64')		
+      , binary = new Buffer((elem.firstChild && elem.firstChild.data) || '', 'base64')
 		  , id = "part" + (parseInt(i)+1)
     
     parts.push({ id: id


### PR DESCRIPTION
Hi,

I've fixed another crash that occurs when you try to send an attached file that is empty. The problem is that the base64 text element that you're expecting and replacing in the MTOM handler is missing because `parseFromString` in `addAttachment` swaps, for example, `<data></data>` with `<data/>`.

Cheers,
Jan