### PR TITLE
Remove superfluous line from security.js

### DIFF
--- a/lib/handlers/client/security/security.js
+++ b/lib/handlers/client/security/security.js
@@ -16,7 +16,6 @@ var END_CERT = "-----END CERTIFICATE-----"
 function SecurityClientHandler(options, tokens) {
   this.options = options || {}
   this.options.excludeTimestamp = this.options.excludeTimestamp || false
-  this.options.responseKeyInfoProvider = this.options.excludeTimestamp || null
   this.options.responseKeyInfoProvider = this.options.responseKeyInfoProvider || null
   this.options.validateResponseSignature = this.options.validateResponseSignature || false
 


### PR DESCRIPTION
This line does nothing and looks like it was created by accident, so it should go.