### PR TITLE
:boom: prevent crash from bad boundary response

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,8 @@ function extractContentId(id) {
 }
 
 function parseBoundary(contentType) {
-  return contentType.match('boundary=\"(.*?)\"')[1]
+  var b = contentType.match('boundary=\"(.*?)\"')
+  return b && (b.length ? b[1] : b)
 }
 
 function dateDiffInMin(d1, d2) {


### PR DESCRIPTION
Just check the match for boundary response without crashing.
No boundary is a :warning: