### PR TITLE
Fixing binary to base64 and to binary again

### DIFF
--- a/lib/handlers/client/mtom/mime-writer.js
+++ b/lib/handlers/client/mtom/mime-writer.js
@@ -16,7 +16,9 @@ var MimeWriter = {
     var return_part = '--' + boundary + "\r\n"
     return_part += "Content-ID: <" + part.id + ">\r\n"
     return_part += "Content-Transfer-Encoding: " + part.encoding + "\r\n"
+    return_part += 'Content-Disposition: attachment; name="' + part.id + '"\r\n'
     return_part += "Content-Type: " + part.contentType + "\r\n\r\n"
+
     return Buffer.concat([new Buffer(return_part), part.body])
   }
 }

--- a/lib/handlers/client/mtom/mtom.js
+++ b/lib/handlers/client/mtom/mtom.js
@@ -20,10 +20,11 @@ MtomClientHandler.prototype.send = function(ctx, callback) {
   var doc = new Dom().parseFromString(ctx.request)
 
   for (var i in ctx.base64Elements) {
-    var file = ctx.base64Elements[i]
-		  , elem = select(doc, file.xpath)[0]
-      , binary = new Buffer((elem.firstChild && elem.firstChild.data) || '', 'base64')
-		  , id = "part" + (parseInt(i)+1)
+    var file = ctx.base64Elements[i];
+		var elem = select(doc, file.xpath)[0];
+
+    var binary = new Buffer(file.content, 'base64');
+		var id = "part" + (parseInt(i)+1);
 
     parts.push({ id: id
                , contentType: file.contentType
@@ -87,4 +88,3 @@ MtomClientHandler.prototype.receive = function(ctx, callback) {
   ctx.response = doc.toString()
   callback(ctx)
 }
-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ function extractContentId(id) {
 
 function parseBoundary(contentType) {
   var b = contentType.match('boundary=\"(.*?)\"')
-  return b && (b.length ? b[1] : b)
+  return b && b.length && b[1]
 }
 
 function dateDiffInMin(d1, d2) {
@@ -103,5 +103,3 @@ exports.parseBoundary = parseBoundary
 exports.dateDiffInMin = dateDiffInMin
 exports.getTypeName = getTypeName
 exports.findAttr = findAttr
-
-

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -45,15 +45,15 @@ function isArray(obj) {
 }
 
 function addAttachment(ctx, property, xpath, file, contentType) {
-  var prop = eval("ctx." + property)
+  var prop = ctx[property]
   , doc = new Dom().parseFromString(prop)
   , elem = select(doc, xpath)[0]
   , content = fs.readFileSync(file).toString("base64")
 
   utils.setElementValue(doc, elem, content)
-  eval("ctx." + property + " = doc.toString()");
+  ctx[property] = doc.toString();
   if (!ctx.base64Elements) ctx.base64Elements = []
-  ctx.base64Elements.push({xpath: xpath, contentType: contentType});
+  ctx.base64Elements.push({xpath: xpath, contentType: contentType, content: content});
 }
 
 function getAttachment(ctx, property, xpath) {


### PR DESCRIPTION
![](https://media.giphy.com/media/cyoN6pC6kek2A/giphy.gif)

The file conversion to base64 in function ws.addAttachment and again to binary in mtom.send didn't work for me. The files were corrupted. So I propose you to use the field content in `ctx.base64Elements.push({xpath: xpath, contentType: contentType, content: content})`  to propagate the file. This way the files were converted fine. I've removed the eval, it was not necessar