### PR TITLE
doc.firstChild is might not be doc.documentElement (xmldom issue 83)

### DIFF
--- a/lib/handlers/client/addressing.js
+++ b/lib/handlers/client/addressing.js
@@ -12,7 +12,7 @@ WsAddressingClientHandler.prototype.send = function(ctx, callback) {
   var self = this
     , doc = new Dom().parseFromString(ctx.request)
     , header = select(doc, "/*[local-name(.)='Envelope']/*[local-name(.)='Header']")[0]
-  doc.firstChild.setAttribute("xmlns:ws", this.version)
+  doc.documentElement.setAttribute("xmlns:ws", this.version)
   utils.appendElement(doc, header, this.version, "ws:Action", ctx.action)
   utils.appendElement(doc, header, this.version, "ws:To", ctx.url)
   utils.appendElement(doc, header, this.version, "ws:MessageID", utils.guid())

--- a/lib/handlers/client/security/security.js
+++ b/lib/handlers/client/security/security.js
@@ -41,8 +41,8 @@ SecurityClientHandler.prototype.send = function(ctx, callback) {
 }
 
 SecurityClientHandler.prototype.AddNamespaces = function(doc) {
-  doc.firstChild.setAttribute("xmlns:u", consts.security_utility_ns)
-  doc.firstChild.setAttribute("xmlns:o", consts.security_ns)
+  doc.documentElement.setAttribute("xmlns:u", consts.security_utility_ns)
+  doc.documentElement.setAttribute("xmlns:o", consts.security_ns)
 }
 
 SecurityClientHandler.prototype.AddTimestamp = function(doc, security) {

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -31,10 +31,10 @@ function send(handlers, ctx, callback) {
 function ensureHasSoapHeader(ctx) {
   var doc = new Dom().parseFromString(ctx.request)
   , header = select(doc, "/*[local-name(.)='Envelope']/*[local-name(.)='Header']")
-  , qname = doc.firstChild.prefix==null ? "" : doc.firstChild.prefix + ":"
+  , qname = doc.documentElement.prefix==null ? "" : doc.documentElement.prefix + ":"
   qname += "Header"
   if (header.length==0) {
-    utils.prependElement(doc, doc.firstChild, doc.firstChild.namespaceURI, qname, null)
+    utils.prependElement(doc, doc.documentElement, doc.documentElement.namespaceURI, qname, null)
   }
 
   ctx.request = doc.toString()

--- a/security.js
+++ b/security.js
@@ -41,8 +41,8 @@ SecurityClientHandler.prototype.send = function(ctx, callback) {
 }
 
 SecurityClientHandler.prototype.AddNamespaces = function(doc) {
-  doc.firstChild.setAttribute("xmlns:u", consts.security_utility_ns)
-  doc.firstChild.setAttribute("xmlns:o", consts.security_ns)
+  doc.documentElement.setAttribute("xmlns:u", consts.security_utility_ns)
+  doc.documentElement.setAttribute("xmlns:o", consts.security_ns)
 }
 
 SecurityClientHandler.prototype.AddTimestamp = function(doc, security) {


### PR DESCRIPTION
I checked the W3C DOM standard doc and the xmldom guys are right: a Document can contain, besides the root document element, ProcessingInstruction nodes (the <?xml...?> thing), a doctype node, and comments. The upshot being, in my case, that passing XML with the XML header already attached to ws.send breaks ensureHasSoapHeader (and probably other things).