### PR TITLE
Added support to timeout option

### DIFF
--- a/lib/handlers/client/http.js
+++ b/lib/handlers/client/http.js
@@ -6,16 +6,22 @@ exports.HttpClientHandler = HttpClientHandler
 function HttpClientHandler() {}
 
 HttpClientHandler.prototype.send = function(ctx, callback) {
-  request.post({ url: ctx.url
-               , body: ctx.request
-               , headers: { "SOAPAction": ctx.action
-                          , "Content-Type": ctx.contentType
-                          , "MIME-Version": "1.0"
-                          }
-               , encoding: null
-	       , rejectUnauthorized: false
-	       , agentOptions: ctx.agentOptions
-               },
+  var options = { url: ctx.url,
+                  body: ctx.request,
+                  headers: { "SOAPAction": ctx.action,
+                            "Content-Type": ctx.contentType,
+                            "MIME-Version": "1.0"
+                          },
+                  encoding: null,
+                  rejectUnauthorized: false,
+                  agentOptions: ctx.agentOptions,
+                }
+
+  if(ctx.timeout !== 'undefined' && ctx.timeout) {
+    options['timeout'] = ctx.timeout
+  }
+  
+  request.post(options,
                function (error, response, body) {
     ctx.response = body
       if (response) {


### PR DESCRIPTION
The code changes help in adding a support to configure timeout for ws requests made using this API.

A new timeout option can be added as:
 var ctx =  { request: request
               , url: "http://service/security"
               , action: "http://tempuri.org/EchoString"
               , contentType: "text/xml"
              **, timeout: 2000**
               }
if no timeout option is provided to the ctx, the API works as is without breaking the core functionality.