### PR TITLE
Add option to support tls.connect().

### DIFF
--- a/lib/handlers/client/http.js
+++ b/lib/handlers/client/http.js
@@ -13,8 +13,10 @@ HttpClientHandler.prototype.send = function(ctx, callback) {
                           , "MIME-Version": "1.0"
                           }
                , encoding: null
-	       , rejectUnauthorized: false
-	       , agentOptions: ctx.agentOptions
+                , rejectUnauthorized: false
+                , agentOptions: ctx.agentOptions
+                , cert: ctx.cert
+                , key: ctx.key
                },
                function (error, response, body) {
     ctx.response = body


### PR DESCRIPTION
Hi Yaronn, 

ws.js is very cool, but why you choose to decorate http with an http handler. It will be more simple to just generate the soap content and let the developper choose how send it.
In my case I need to attach a certificate to the http request. So I've created 2 new properties: cert and key. If you just generate the soap content you would not have to manage this kind of issue.

The pattern "chain of responsibility" is not a good choice because some handlers need to be define before others.

Benoît.