### PR TITLE
update formidable to use version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "author": "Yaron Naveh (yaronn01@gmail.com, http://webservices20.blogspot.com/)",
     "dependencies": {
         "bufferjs": ">= 1.0.2",
-        "formidable": "=1.0.9",
+        "formidable": "=1.1.1",
         "request": ">=2.9.100",
         "xmldom": "=0.1.7",
         "dateformat": ">=1.0.2-1.2.3",


### PR DESCRIPTION
See following issue for discussion on error:
Buffer.write(string, encoding, offset[, length]) is no longer supported
https://github.com/yaronn/wcf.js/issues/16

maybe even would consider changing to ^1.1.1