### PR TITLE
addAttachment with buffer.

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -47,8 +47,11 @@ function isArray(obj) {
 function addAttachment(ctx, property, xpath, file, contentType) {
   var prop = ctx[property]
   , doc = new Dom().parseFromString(prop)
-  , elem = select(doc, xpath)[0]
-  , content = fs.readFileSync(file).toString("base64")
+  , elem = select(doc, xpath)[0];
+  var content;
+	
+  if (Buffer.isBuffer(file) content = file.toString("base64");
+  else content = fs.readFileSync(file).toString("base64")
 
   utils.setElementValue(doc, elem, content)
   ctx[property] = doc.toString();


### PR DESCRIPTION
Create an attachment with buffer without reading file.